### PR TITLE
Fixed docs to only build when tag changes

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "v*.*.*"
 
 jobs:
   docs:
@@ -37,6 +39,7 @@ jobs:
         working_directory: _build/latex
         root_file: AguaClaraTextbook.tex
     - name: Create Release
+      id: create-release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Contains the details of an AguaClara design for the unit process. Goes over logi
 Contains working theories in the AguaClara lab and future research projects to better understand the physics of water treatment and improve plant design.
 
 ## Publishing
-
 To publish, first ensure all of your changes have been merged into master by following the Pull Request best practices [here](https://github.com/AguaClara/Textbook/wiki/Contributing-by-writing). Then follow these steps:
 
 1. `git checkout master`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Textbook [![Build Status](https://travis-ci.org/AguaClara/Textbook.svg?branch=master)](https://travis-ci.org/AguaClara/Textbook)
+# Textbook [![Documentation](https://github.com/AguaClara/Textbook/workflows/Documentation/badge.svg)](https://aguaclara.github.io/Textbook/)
 
 Please enjoy [the AguaClara textbook](https://aguaclara.github.io/Textbook/)!  
 If you are interested in helping out by writing, begin by reading [this page](https://github.com/AguaClara/Textbook/wiki/Contributing-by-writing)!  
@@ -29,6 +29,18 @@ Contains the details of an AguaClara design for the unit process. Goes over logi
 
 ## Theory and Future Work
 Contains working theories in the AguaClara lab and future research projects to better understand the physics of water treatment and improve plant design.
+
+## Publishing
+
+To publish, first ensure all of your changes have been merged into master by following the Pull Request best practices [here](https://github.com/AguaClara/Textbook/wiki/Contributing-by-writing). Then follow these steps:
+
+1. `git checkout master`
+2. `git pull`
+3. `git tag <tagname>`
+   1. To get `<tagname>`, check the latest release and increment by 1, following semantic versioning. For Example, if the current version were `v0.0.76` and there were only small edits the next would be `v0.0.77`. If there were more significant changes it would be `v0.1.0`, and for extremely large changes (maybe a whole new chapter?), `v1.0.0`.
+4. `git push origin <tagname>`
+
+Pushing a tag will kick off the automated release workflow which builds the PDF and HTML documentation.
 
 ## Appendix A: Derivations
 Many of the equations that show up in the `Introduction` and `Design` sections have lengthy derivations that have been done by AguaClara in the past. The step-by-step derivations of these equations will be found in this section. Equations that require derivations will be noted as such in the text and linked to their derivations.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ Pygments==2.2.0
 pyparsing==2.2.0
 python-dateutil==2.7.3
 pytz==2018.5
-PyYAML==3.13
+PyYAML==5.1
 requests==2.24.0
 six==1.11.0
 snowballstemmer==1.2.1


### PR DESCRIPTION
Changing build workflow to only release with tags. Added steps on how to do so to README.md:

## Publishing
To publish, first ensure all of your changes have been merged into master by following the Pull Request best practices [here](https://github.com/AguaClara/Textbook/wiki/Contributing-by-writing). Then follow these steps:

1. `git checkout master`
2. `git pull`
3. `git tag <tagname>`
   1. To get `<tagname>`, check the latest release and increment by 1, following semantic versioning. For Example, if the current version were `v0.0.76` and there were only small edits the next would be `v0.0.77`. If there were more significant changes it would be `v0.1.0`, and for extremely large changes (maybe a whole new chapter?), `v1.0.0`.
4. `git push origin <tagname>`

Pushing a tag will kick off the automated release workflow which builds the PDF and HTML documentation.
